### PR TITLE
Added properties file

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+
+jwt.secret=guest
+spring.datasource.url=jdbc:h2:mem:memdb
+spring.h2.console.enabled=true
+spring.jpa.defer-datasource-initialization=true
+spring.mail.host=smtp.gmail.com
+spring.mail.port=465
+spring.mail.properties.mail.smtp.auth=false
+spring.mail.properties.mail.smtp.starttls.enable=false


### PR DESCRIPTION
DefectDumper wasn't running data.sql, and wasn't creating a database with User table automatically via @Entity and @Table, because it needed spring.jpa.defer-datasource-initialization to be true, which I marked in the applications.properties file included in this PR. Since it is marked true, Spring Boot will run the tables based on the annotations (@Table and @Entity) marking the User class in Models. 