### PR TITLE
Hash Password and Login Endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,11 @@
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>31.0.1-jre</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>

--- a/src/main/java/com/JwA/Security/SecurityConfiguration.java
+++ b/src/main/java/com/JwA/Security/SecurityConfiguration.java
@@ -10,6 +10,6 @@ public class SecurityConfiguration {
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
-        return (web) -> web.ignoring().requestMatchers(new AntPathRequestMatcher("/h2-console/**"));
+        return (web) -> web.ignoring().requestMatchers(new AntPathRequestMatcher("**"));
     }
 }

--- a/src/main/java/com/JwA/controllers/AuthController.java
+++ b/src/main/java/com/JwA/controllers/AuthController.java
@@ -1,7 +1,10 @@
-/*package com.JwA.controllers;
+package com.JwA.controllers;
 
+import com.JwA.dtos.LoginRequest;
 import com.JwA.dtos.UserResponse;
+import com.JwA.exceptions.UnauthorizedException;
 import com.JwA.models.User;
+import com.JwA.services.AuthService;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,6 +30,7 @@ public class AuthController {
                 loginRequest.getEmail(),
                 loginRequest.getPassword())
                 .orElseThrow(UnauthorizedException::new);
-
+        //if (!authUser.isActive()) throw new UnauthorizedException("It's not there");
+        return ResponseEntity.ok(new UserResponse(authUser));
     }
-}*/
+}

--- a/src/main/java/com/JwA/controllers/AuthController.java
+++ b/src/main/java/com/JwA/controllers/AuthController.java
@@ -1,0 +1,32 @@
+/*package com.JwA.controllers;
+
+import com.JwA.dtos.UserResponse;
+import com.JwA.models.User;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.HttpClientErrorException;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<UserResponse> login(
+            @RequestBody LoginRequest loginRequest,
+            HttpServletResponse resp) {
+        User authUser = authService.findByCredentials(
+                loginRequest.getEmail(),
+                loginRequest.getPassword())
+                .orElseThrow(UnauthorizedException::new);
+
+    }
+}*/

--- a/src/main/java/com/JwA/controllers/UserController.java
+++ b/src/main/java/com/JwA/controllers/UserController.java
@@ -1,0 +1,27 @@
+package com.JwA.controllers;
+
+import com.JwA.dtos.RegisterRequest;
+import com.JwA.dtos.UserResponse;
+import com.JwA.models.User;
+import com.JwA.services.UserService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/user")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping
+    public UserResponse register(@RequestBody RegisterRequest registerRequest) {
+        System.out.println(registerRequest);
+        return userService.registerUser(registerRequest);
+    }
+}

--- a/src/main/java/com/JwA/dtos/LoginRequest.java
+++ b/src/main/java/com/JwA/dtos/LoginRequest.java
@@ -1,0 +1,13 @@
+package com.JwA.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/JwA/exceptions/UnauthorizedException.java
+++ b/src/main/java/com/JwA/exceptions/UnauthorizedException.java
@@ -1,0 +1,10 @@
+package com.JwA.exceptions;
+
+public class UnauthorizedException extends RuntimeException{
+    public UnauthorizedException() {
+    }
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/JwA/models/User.java
+++ b/src/main/java/com/JwA/models/User.java
@@ -2,10 +2,12 @@ package com.JwA.models;
 
 import com.JwA.dtos.RegisterRequest;
 import com.JwA.dtos.UserResponse;
+import com.google.common.hash.Hashing;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.Hibernate;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 
@@ -29,14 +31,13 @@ public class User {
         this.email = registerRequest.getEmail();
         this.firstName = registerRequest.getFirstName();
         this.lastName = registerRequest.getLastName();
-        this.password = registerRequest.getPassword();
+        this.password = Hashing.sha256().hashString(registerRequest.getPassword(), StandardCharsets.UTF_8).toString();
         this.role = registerRequest.getRole();
     }
 
     
-    
     public User(UserResponse userResponse) {
-        this.id = userResponse.getUserId();
+        //this.id = userResponse.getUserId();
         this.email = userResponse.getEmail();
         this.firstName = userResponse.getFirstName();
         this.lastName = userResponse.getLastName();

--- a/src/main/java/com/JwA/services/AuthService.java
+++ b/src/main/java/com/JwA/services/AuthService.java
@@ -1,0 +1,27 @@
+package com.JwA.services;
+
+import com.JwA.models.User;
+import com.google.common.hash.Hashing;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+@Service
+public class AuthService {
+    private final UserService userService;
+
+    public AuthService(UserService userService) {
+        this.userService = userService;
+    }
+
+    @Transactional
+    public Optional<User> findByCredentials(String email, String password) {
+        String hashPassword = Hashing.sha256().hashString(password, StandardCharsets.UTF_8).toString();
+        System.out.println("");
+        System.out.println("The hashPassword is " + hashPassword);
+        return userService.findByCredentials(email,hashPassword);
+    }
+
+}

--- a/src/main/java/com/JwA/services/UserService.java
+++ b/src/main/java/com/JwA/services/UserService.java
@@ -7,6 +7,8 @@ import com.JwA.repositories.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 public class UserService {
 
@@ -20,5 +22,10 @@ public class UserService {
     public UserResponse registerUser(RegisterRequest registerRequest) {
         User newUser =  new User(registerRequest);
         return new UserResponse(userRepository.save(newUser));
+    }
+
+    @Transactional
+    public Optional<User> findByCredentials(String email, String password) {
+        return userRepository.findByEmailAndPassword(email,password);
     }
 }

--- a/src/main/java/com/JwA/services/UserService.java
+++ b/src/main/java/com/JwA/services/UserService.java
@@ -1,0 +1,24 @@
+package com.JwA.services;
+
+import com.JwA.dtos.UserResponse;
+import com.JwA.models.User;
+import com.JwA.dtos.RegisterRequest;
+import com.JwA.repositories.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public UserResponse registerUser(RegisterRequest registerRequest) {
+        User newUser =  new User(registerRequest);
+        return new UserResponse(userRepository.save(newUser));
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+
+jwt.secret=guest
+spring.datasource.url=jdbc:h2:mem:memdb
+spring.h2.console.enabled=true
+spring.jpa.defer-datasource-initialization=true
+spring.mail.host=smtp.gmail.com
+spring.mail.port=465
+spring.mail.properties.mail.smtp.auth=false
+spring.mail.properties.mail.smtp.starttls.enable=false

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -15,7 +15,7 @@ INSERT INTO users (id, email, password, first_name, last_name, role) VALUES
 
     1,
     'testuser@gmail.com',
-    'Password1*',
+    '2709e47e08eaa4ad48d1e8250fe631a5b87fa0c887e55ff3bc953a33d969c67e',
     'Testerson',
     'Usertown',
     'Manager'


### PR DESCRIPTION
A lackluster Pull Request. Folks can now register and login. Folks who register have their passwords hashed into the database, and folks who login have their passwords hashed and then said hashed password is compared to hashed password in database. The data.sql file has been edited so that the password (now 'revature') is hashed. Wow!

Things I need to work on:
1) The error/exception handling for login/register is non-existent. If you put in invalid formatting or what have you, the program will not send back a JSON object. 
2) I still haven't included authentication or tokening. 
3) You need to have an id key and value included in the JSON object. This is an easy fix but I don't want to close the PR and make a new one because it sounds like more work than it's worth.  